### PR TITLE
feat: expose current and historical data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,23 @@ print(patient_list)
 
 ### Getting Patient data
 
-Retrieve patient data using the `get_graph_data` method:
+Retrieve patient data using the `read` method:
 
 ```python
 patient = client.get_patient_list()[0]
-patient_data = client.get_graph_data(patient_id=patient.patient_id)
+patient_data = client.read(patient_id=patient.patient_id)
+```
+
+Get the latest glucose data:
+
+```python
+latest_glucose = patient_data.current
+print(latest_glucose)
+```
+
+Get the historical glucose data:
+
+```python
+historical_glucose = patient_data.history
+print(historical_glucose)
 ```

--- a/src/pylibrelinkup/client.py
+++ b/src/pylibrelinkup/client.py
@@ -66,12 +66,16 @@ class Client:
         data = r.json()
         return [Patient.model_validate(patient) for patient in data["data"]]
 
-    def get_graph_data(self, patient_id: UUID) -> ConnectionResponse:
-        """Requests and returns patient graph data"""
+    def _get_graph_data_json(self, patient_id: UUID) -> dict:
         r = requests.get(
             url=f"{self.api_url}/llu/connections/{patient_id}/graph",
             headers=self.HEADERS,
         )
         r.raise_for_status()
+        return r.json()
 
-        return ConnectionResponse.model_validate(r.json())
+    def read(self, patient_id: UUID) -> ConnectionResponse:
+        """Requests and returns patient data"""
+        response_json = self._get_graph_data_json(patient_id)
+
+        return ConnectionResponse.model_validate(response_json)

--- a/src/pylibrelinkup/models/connection.py
+++ b/src/pylibrelinkup/models/connection.py
@@ -8,7 +8,7 @@ from pydantic import (
 from pydantic.alias_generators import to_camel
 
 from .config import AlarmRules
-from .data import GlucoseItem
+from .data import GlucoseMeasurement
 from .hardware import Sensor, PatientDevice, ActiveSensor
 
 
@@ -33,8 +33,8 @@ class Connection(BaseModel):
     uom: int
     sensor: Sensor
     alarm_rules: AlarmRules
-    glucose_measurement: GlucoseItem
-    glucose_item: GlucoseItem
+    glucose_measurement: GlucoseMeasurement
+    glucose_item: GlucoseMeasurement
     glucose_alarm: None
     patient_device: PatientDevice
     created: int
@@ -52,7 +52,7 @@ class Data(BaseModel):
 
     connection: Connection
     active_sensors: list[ActiveSensor] = Field(alias="activeSensors")
-    graph_data: list[GlucoseItem] = Field(alias="graphData")
+    graph_data: list[GlucoseMeasurement] = Field(alias="graphData")
 
 
 class Ticket(BaseModel):
@@ -83,3 +83,18 @@ class ConnectionResponse(BaseModel):
     status: int
     data: Data
     ticket: Ticket
+
+    @property
+    def current(self) -> GlucoseMeasurement:
+        """Returns the current glucose measurement."""
+        return self.data.connection.glucose_measurement
+
+    @property
+    def history(self) -> list[GlucoseMeasurement]:
+        """Returns the historical glucose measurements."""
+        return self.data.graph_data
+
+    @property
+    def raw(self):
+        """Returns the raw JSON data returned by the API."""
+        return self.data.model_dump_json()

--- a/src/pylibrelinkup/models/data.py
+++ b/src/pylibrelinkup/models/data.py
@@ -34,7 +34,7 @@ class Trend(IntEnum):
     UP_FAST: int = 5
 
 
-class GlucoseItem(BaseModel):
+class GlucoseMeasurement(BaseModel):
     """GlucoseMeasurement class to store glucose measurement data."""
 
     model_config = ConfigDict(
@@ -75,7 +75,7 @@ class GlucoseItem(BaseModel):
         return datetime_value
 
 
-class GlucoseItemTrend(GlucoseItem):
+class GlucoseMeasurementTrend(GlucoseMeasurement):
     trend_arrow: Trend
 
     def __str__(self):


### PR DESCRIPTION
* **Breaking change**: `get_graph_data` client method is removed. Use `read` method instead.
* Adds `current` property to `ConnectionResponse` model to simplify retrieval of the current `GlucoseMeasurement` item
* Adds `history` property to `ConnectionResponse` model to simplify retrieval of the list of `GlucoseMeasurement` items used to populate the graph
* Adds `raw` property to `ConnectionResponse` model to allow access to raw json returned by the LibreLinkup API

Closes #1 