### PR TITLE
Refactor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 import responses
+
+from pylibrelinkup import PyLibreLinkUp, APIUrl
 
 
 @pytest.fixture
@@ -27,3 +30,22 @@ def graph_response_no_sd_json():
 def terms_of_use_response_json():
     with open(Path(__file__).parent / "data" / "terms_of_use_response.json") as f:
         return json.loads(f.read())
+
+
+@dataclass
+class PyLibreLinkUpClientFixture:
+    client: PyLibreLinkUp
+    api_url: APIUrl
+
+
+@pytest.fixture(params=APIUrl)
+def api_url(request) -> APIUrl:
+    return request.param
+
+
+@pytest.fixture()
+def pylibrelinkup_client(api_url: APIUrl) -> PyLibreLinkUpClientFixture:
+    return PyLibreLinkUpClientFixture(
+        client=PyLibreLinkUp(email="parp", password="parp", api_url=api_url),
+        api_url=api_url,
+    )

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -8,11 +8,10 @@ from pylibrelinkup import PyLibreLinkUp, APIUrl, AuthenticationError, TermsOfUse
 from pylibrelinkup.models.login import (
     LoginResponse,
 )
-from tests.conftest import mocked_responses
+from tests.conftest import mocked_responses, pylibrelinkup_client
 from tests.factories import LoginResponseFactory
 
 
-@pytest.mark.parametrize("api_url", APIUrl)
 def test_client_uses_correct_api_url_default():
     """Test that the client uses the correct API URL by default."""
     client = PyLibreLinkUp(email="parp", password="parp")
@@ -20,24 +19,23 @@ def test_client_uses_correct_api_url_default():
 
 
 def test_authenticate_raises_error_on_incorrect_login(
-    mocked_responses, api_url: APIUrl
+    mocked_responses, pylibrelinkup_client
 ):
     """Test that the authenticate method raises an error when the login fails."""
     mocked_responses.add(
         responses.POST,
-        f"{api_url.value}/llu/auth/login",
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
         json={"not": "important"},
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=api_url)
-
     with pytest.raises(AuthenticationError):
-        client.authenticate()
+        pylibrelinkup_client.client.authenticate()
 
 
-@pytest.mark.parametrize("api_url", APIUrl)
-def test_authenticate_sets_token_on_correct_login(mocked_responses, api_url: APIUrl):
+def test_authenticate_sets_token_on_correct_login(
+    mocked_responses, pylibrelinkup_client
+):
     """Test that the authenticate method sets the token on a successful login."""
     response = LoginResponseFactory.build()
     response.data.authTicket.token = "parp"
@@ -45,66 +43,57 @@ def test_authenticate_sets_token_on_correct_login(mocked_responses, api_url: API
 
     mocked_responses.add(
         responses.POST,
-        f"{api_url.value}/llu/auth/login",
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
         json=json.loads(response.model_dump_json()),
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=api_url)
+    pylibrelinkup_client.client.authenticate()
 
-    client.authenticate()
-
-    assert client.token == "parp"
+    assert pylibrelinkup_client.client.token == "parp"
 
 
-@pytest.mark.parametrize("api_url", APIUrl)
 def test_authenticate_raises_error_on_invalid_response(
-    mocked_responses, api_url: APIUrl
+    mocked_responses, pylibrelinkup_client
 ):
     """Test that the authenticate method raises an error on invalid response."""
     mocked_responses.add(
         responses.POST,
-        f"{api_url.value}/llu/auth/login",
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
         json={"invalid": "response"},
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=api_url)
-
     with pytest.raises(AuthenticationError):
-        client.authenticate()
+        pylibrelinkup_client.client.authenticate()
 
 
-@pytest.mark.parametrize("api_url", APIUrl)
-def test_authenticate_raises_error_on_http_error(mocked_responses, api_url: APIUrl):
+def test_authenticate_raises_error_on_http_error(
+    mocked_responses, pylibrelinkup_client
+):
     """Test that the authenticate method raises an error on HTTP error."""
     mocked_responses.add(
         responses.POST,
-        f"{api_url.value}/llu/auth/login",
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
         json={"error": "Unauthorized"},
         status=401,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=api_url)
-
     with pytest.raises(requests.exceptions.HTTPError):
-        client.authenticate()
+        pylibrelinkup_client.client.authenticate()
 
 
-@pytest.mark.parametrize("api_url", APIUrl)
 def test_authenticate_raises_terms_of_use_error(
-    mocked_responses, api_url: APIUrl, terms_of_use_response_json
+    mocked_responses, pylibrelinkup_client, terms_of_use_response_json
 ):
     """Test that the authenticate method raises a TermsOfUseError, when the user needs to accept terms of use."""
 
     mocked_responses.add(
         responses.POST,
-        f"{api_url.value}/llu/auth/login",
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
         json=terms_of_use_response_json,
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=api_url)
-
     with pytest.raises(TermsOfUseError):
-        client.authenticate()
+        pylibrelinkup_client.client.authenticate()

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -13,6 +13,12 @@ from tests.factories import LoginResponseFactory
 
 
 @pytest.mark.parametrize("api_url", APIUrl)
+def test_client_uses_correct_api_url_default():
+    """Test that the client uses the correct API URL by default."""
+    client = PyLibreLinkUp(email="parp", password="parp")
+    assert client.api_url == APIUrl.US.value
+
+
 def test_authenticate_raises_error_on_incorrect_login(
     mocked_responses, api_url: APIUrl
 ):

--- a/tests/test_client_read.py
+++ b/tests/test_client_read.py
@@ -8,30 +8,30 @@ from tests.conftest import graph_response_json
 from tests.factories import PatientFactory
 
 
-def test_read_raises_authentication_error_for_unauthenticated_client():
+def test_read_raises_authentication_error_for_unauthenticated_client(
+    pylibrelinkup_client,
+):
     """Test that the read method raises ValueError for an unauthenticated client."""
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.EU)
     with pytest.raises(AuthenticationError, match="PyLibreLinkUp not authenticated"):
-        client.read(UUID("12345678-1234-5678-1234-567812345678"))
+        pylibrelinkup_client.client.read(UUID("12345678-1234-5678-1234-567812345678"))
 
 
 def test_read_returns_connection_response_for_valid_uuid(
-    mocked_responses, graph_response_json
+    mocked_responses, graph_response_json, pylibrelinkup_client
 ):
     """Test that the read method returns ConnectionResponse for a valid UUID."""
     patient_id = UUID("12345678-1234-5678-1234-567812345678")
 
     mocked_responses.add(
         responses.GET,
-        f"{APIUrl.US.value}/llu/connections/{patient_id}/graph",
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
         json=graph_response_json,
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.US)
-    client.token = "not_a_token"
+    pylibrelinkup_client.client.token = "not_a_token"
 
-    result = client.read(patient_id)
+    result = pylibrelinkup_client.client.read(patient_id)
 
     assert isinstance(result, ConnectionResponse)
     assert (
@@ -41,22 +41,21 @@ def test_read_returns_connection_response_for_valid_uuid(
 
 
 def test_read_returns_connection_response_for_valid_patient(
-    mocked_responses, graph_response_json
+    mocked_responses, graph_response_json, pylibrelinkup_client
 ):
     """Test that the read method returns ConnectionResponse for a valid Patient."""
     patient = PatientFactory.build()
 
     mocked_responses.add(
         responses.GET,
-        f"{APIUrl.US.value}/llu/connections/{patient.patient_id}/graph",
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient.patient_id}/graph",
         json=graph_response_json,
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.US)
-    client.token = "not_a_token"
+    pylibrelinkup_client.client.token = "not_a_token"
 
-    result = client.read(patient)
+    result = pylibrelinkup_client.client.read(patient)
 
     assert isinstance(result, ConnectionResponse)
     assert (
@@ -66,22 +65,21 @@ def test_read_returns_connection_response_for_valid_patient(
 
 
 def test_read_returns_connection_response_for_valid_string(
-    mocked_responses, graph_response_json
+    mocked_responses, graph_response_json, pylibrelinkup_client
 ):
     """Test that the read method returns ConnectionResponse for a valid string representation of a UUID."""
     patient_id = "12345678-1234-5678-1234-567812345678"
 
     mocked_responses.add(
         responses.GET,
-        f"{APIUrl.US.value}/llu/connections/{patient_id}/graph",
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
         json=graph_response_json,
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.US)
-    client.token = "not_a_token"
+    pylibrelinkup_client.client.token = "not_a_token"
 
-    result = client.read(patient_id)
+    result = pylibrelinkup_client.client.read(patient_id)
 
     assert isinstance(result, ConnectionResponse)
     assert (
@@ -90,41 +88,40 @@ def test_read_returns_connection_response_for_valid_string(
     )
 
 
-def test_read_raises_value_error_for_invalid_uuid_string(mocked_responses):
+def test_read_raises_value_error_for_invalid_uuid_string(
+    mocked_responses, pylibrelinkup_client
+):
     """Test that the read method raises ValueError for an invalid UUID string."""
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.US)
-    client.token = "not_a_token"
+    pylibrelinkup_client.client.token = "not_a_token"
 
     with pytest.raises(ValueError, match="Invalid patient_identifier"):
-        client.read("i'm not a uuid")
+        pylibrelinkup_client.client.read("i'm not a uuid")
 
 
-def test_read_raises_value_error_for_invalid_patient_id_type():
+def test_read_raises_value_error_for_invalid_patient_id_type(pylibrelinkup_client):
     """Test that the read method raises ValueError for an invalid patient_id type."""
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.EU2)
-    client.token = "not_a_token"
+    pylibrelinkup_client.client.token = "not_a_token"
 
     with pytest.raises(ValueError, match="Invalid patient_identifier"):
-        client.read(123456)
+        pylibrelinkup_client.client.read(123456)  # type: ignore
 
 
 def test_read_response_no_sd_returns_connection_response(
-    mocked_responses, graph_response_no_sd_json
+    mocked_responses, graph_response_no_sd_json, pylibrelinkup_client
 ):
-    """Test that the read method returns ConnectionResponse for a valid UUID."""
+    """Test that the read method returns ConnectionResponse when no sd key is present in llu api response data."""
     patient_id = UUID("12345678-1234-5678-1234-567812345678")
 
     mocked_responses.add(
         responses.GET,
-        f"{APIUrl.US.value}/llu/connections/{patient_id}/graph",
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
         json=graph_response_no_sd_json,
         status=200,
     )
 
-    client = PyLibreLinkUp(email="parp", password="parp", api_url=APIUrl.US)
-    client.token = "not_a_token"
+    pylibrelinkup_client.client.token = "not_a_token"
 
-    result = client.read(patient_id)
+    result = pylibrelinkup_client.client.read(patient_id)
 
     assert isinstance(result, ConnectionResponse)
     assert (


### PR DESCRIPTION
* Adds a test for the default API URL used by the `PyLibreLinkUp` client
* Introduces common `pylibrelinkup_client` fixture for `PyLibreLinkUp` instance, and parameterises it with `APIUrl` values
* Uses `pylibrelinkup_client` within all required tests