### PR TITLE
Update patient model string representation

### DIFF
--- a/src/pylibrelinkup/models/data.py
+++ b/src/pylibrelinkup/models/data.py
@@ -34,8 +34,11 @@ class Patient(BaseModel):
     first_name: str
     last_name: str
 
+    def __repr__(self):
+        return f"{self.first_name} {self.last_name}: {self.patient_id}"
+
     def __str__(self):
-        return f"{self.first_name} {self.last_name}: {self.id}"
+        return f"{self.first_name} {self.last_name}: {self.patient_id}"
 
 
 class Trend(IntEnum):

--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Union
 from uuid import UUID
 
 import requests


### PR DESCRIPTION
Update the string representation of the `Patient` class, so that it uses the `patient_id` value rather than the internal `id` value, since `patient_id` is the one used when accessing data, so is likely the most commonly required value.