### PR TITLE
feat: Add all known region api urls

### DIFF
--- a/src/pylibrelinkup/api_url.py
+++ b/src/pylibrelinkup/api_url.py
@@ -10,6 +10,14 @@ class APIUrl(StrEnum):
     EU = "https://api-eu.libreview.io"
     EU2 = "https://api-eu2.libreview.io"
     US = "https://api.libreview.io"
+    AE = "https://api-ae.libreview.io"
+    AP = "https://api-ap.libreview.io"
+    AU = "https://api-au.libreview.io"
+    CA = "https://api-ca.libreview.io"
+    DE = "https://api-de.libreview.io"
+    FR = "https://api-fr.libreview.io"
+    JP = "https://api-jp.libreview.io"
+    LA = "https://api-la.libreview.io"
 
     @classmethod
     def from_string(cls: Type[APIUrl], value: str) -> APIUrl:


### PR DESCRIPTION
Update the `APIUrl` enum to include all known region subdomains

closes #22 