### PR TITLE
Fix `ValueError` being thrown when authentication receives a redirect response

### DIFF
--- a/src/pylibrelinkup/api_url.py
+++ b/src/pylibrelinkup/api_url.py
@@ -21,7 +21,8 @@ class APIUrl(StrEnum):
 
     @classmethod
     def from_string(cls: Type[APIUrl], value: str) -> APIUrl:
+        member: APIUrl
         for member in cls:
-            if member.lower() == value.lower():
+            if member.name.lower() == value.lower():
                 return cast(APIUrl, member)
         raise ValueError(f"{value} is not a valid {cls.__name__}")

--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -52,7 +52,7 @@ class PyLibreLinkUp:
         try:
             data_dict = data.get("data", {})
             if data_dict.get("redirect", False):
-                raise RedirectError(APIUrl.from_string(data_dict["region"]))
+                raise RedirectError(APIUrl.from_string(data_dict["region"].upper()))
 
             if data_dict.get("step", {}).get("type") == "tou":
                 raise TermsOfUseError()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,12 @@ def terms_of_use_response_json():
         return json.loads(f.read())
 
 
+@pytest.fixture
+def redirect_response_json():
+    with open(Path(__file__).parent / "data" / "redirect_response.json") as f:
+        return json.loads(f.read())
+
+
 @dataclass
 class PyLibreLinkUpClientFixture:
     client: PyLibreLinkUp

--- a/tests/data/redirect_response.json
+++ b/tests/data/redirect_response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "redirect": true,
+    "region": "eu2"
+  },
+  "status": 0
+}

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -4,7 +4,13 @@ import pytest
 import requests
 import responses
 
-from pylibrelinkup import PyLibreLinkUp, APIUrl, AuthenticationError, TermsOfUseError
+from pylibrelinkup import (
+    PyLibreLinkUp,
+    APIUrl,
+    AuthenticationError,
+    TermsOfUseError,
+    RedirectError,
+)
 from pylibrelinkup.models.login import (
     LoginResponse,
 )
@@ -96,4 +102,20 @@ def test_authenticate_raises_terms_of_use_error(
     )
 
     with pytest.raises(TermsOfUseError):
+        pylibrelinkup_client.client.authenticate()
+
+
+def test_redirection_response_raises_redirect_error(
+    mocked_responses, pylibrelinkup_client, redirect_response_json
+):
+    """Test that the authenticate method raises a RedirectError, when the user is redirected to a different region."""
+
+    mocked_responses.add(
+        responses.POST,
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
+        json=redirect_response_json,
+        status=200,
+    )
+
+    with pytest.raises(RedirectError):
         pylibrelinkup_client.client.authenticate()


### PR DESCRIPTION
Handle the redirect response correctly, by casting the received string to uppercase, and testing against the Enum name

Fixes #25 