### PR TITLE
Pylibrelinkup 24 privacy policy

### DIFF
--- a/src/pylibrelinkup/exceptions.py
+++ b/src/pylibrelinkup/exceptions.py
@@ -24,3 +24,10 @@ class TermsOfUseError(Exception):
 
     def __init__(self):
         super().__init__("User needs to accept terms of use. ")
+
+
+class PrivacyPolicyError(Exception):
+    """Raised when the user needs to accept the privacy policy."""
+
+    def __init__(self):
+        super().__init__("User needs to accept the privacy policy. ")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,12 @@ def terms_of_use_response_json():
 
 
 @pytest.fixture
+def privacy_policy_response_json():
+    with open(Path(__file__).parent / "data" / "privacy_policy_response.json") as f:
+        return json.loads(f.read())
+
+
+@pytest.fixture
 def redirect_response_json():
     with open(Path(__file__).parent / "data" / "redirect_response.json") as f:
         return json.loads(f.read())

--- a/tests/data/privacy_policy_response.json
+++ b/tests/data/privacy_policy_response.json
@@ -1,0 +1,24 @@
+{
+  "status": 4,
+  "data": {
+    "step": {
+      "type": "pp",
+      "componentName": "AcceptDocument",
+      "props": {
+        "reaccept": true,
+        "titleKey": "Common.privacyPolicy",
+        "type": "pp"
+      }
+    },
+    "user": {
+      "accountType": "pat",
+      "country": "CA",
+      "uiLanguage": "fr-CA"
+    },
+    "authTicket": {
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjZlZGFjNDk2LWQyNGUtMTFlYy04ZTVkLTAyNDJhYzExMDAwMiIsImZpcnN0TmFtZSI6IkhhbGltZSBTZWxjdWsiLCJsYXN0TmFtZSI6Iktla2VjIiwiY291bnRyeSI6IkRFIiwicmVnaW9uIjoiZXUiLCJyb2xlIjoicGF0aWVudCIsInVuaXRzIjoxLCJwcmFjdGljZXMiOltdLCJjIjoxLCJzIjoibGx1LmFuZHJvaWQiLCJleHAiOjE2Njg2OTIzNTl9.LK8Ejr2IDKGM7oiObVYMHC8HV2bPcv6obt7UiEFXXXX",
+      "expires": 1730567336,
+      "duration": 3600000
+    }
+  }
+}

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -11,6 +11,7 @@ from pylibrelinkup import (
     TermsOfUseError,
     RedirectError,
 )
+from pylibrelinkup.exceptions import PrivacyPolicyError
 from pylibrelinkup.models.login import (
     LoginResponse,
 )
@@ -102,6 +103,22 @@ def test_authenticate_raises_terms_of_use_error(
     )
 
     with pytest.raises(TermsOfUseError):
+        pylibrelinkup_client.client.authenticate()
+
+
+def test_authenticate_raises_privacy_policy_error(
+    mocked_responses, pylibrelinkup_client, privacy_policy_response_json
+):
+    """Test that the authenticate method raises a PrivacyPolicyError, when the user needs to accept the privacy policy."""
+
+    mocked_responses.add(
+        responses.POST,
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
+        json=privacy_policy_response_json,
+        status=200,
+    )
+
+    with pytest.raises(PrivacyPolicyError):
         pylibrelinkup_client.client.authenticate()
 
 


### PR DESCRIPTION
This pull request introduces a new exception for handling privacy policy acceptance and updates the authentication flow and tests accordingly. The most important changes include adding the `PrivacyPolicyError` exception, updating the `authenticate` method to handle privacy policy acceptance, and adding corresponding tests.

### Exception Handling Updates:
* Added `PrivacyPolicyError` exception class to handle cases where the user needs to accept the privacy policy in `src/pylibrelinkup/exceptions.py`.

### Authentication Flow Updates:
* Updated the `authenticate` method in `src/pylibrelinkup/pylibrelinkup.py` to raise `PrivacyPolicyError` when the user needs to accept the privacy policy.

### Test Updates:
* Added fixture for `privacy_policy_response_json` in `tests/conftest.py` to provide test data for privacy policy acceptance scenarios.
* Added `tests/data/privacy_policy_response.json` to simulate a privacy policy acceptance response.
* Added test `test_authenticate_raises_privacy_policy_error` in `tests/test_client_authentication.py` to verify that the `authenticate` method raises `PrivacyPolicyError` when required.

Fixes #24 