### PR TITLE
Handle the case where the user's email requires verification

### DIFF
--- a/src/pylibrelinkup/exceptions.py
+++ b/src/pylibrelinkup/exceptions.py
@@ -3,13 +3,19 @@ from .api_url import APIUrl
 __all__ = ["AuthenticationError", "RedirectError", "TermsOfUseError"]
 
 
-class AuthenticationError(Exception):
+class PyLibreLinkUpError(Exception):
+    """Base class for PyLibreLinkUp exceptions."""
+
+    pass
+
+
+class AuthenticationError(PyLibreLinkUpError):
     """Raised when authentication fails."""
 
     pass
 
 
-class RedirectError(Exception):
+class RedirectError(PyLibreLinkUpError):
     """Raised when a redirect is encountered during authentication. This is a signal to retry the request with the new region.
     The new region is stored in the `region` attribute of the exception, which is an APIUrl enum value.
     """
@@ -19,15 +25,22 @@ class RedirectError(Exception):
         super().__init__(f"Redirected to {region}")
 
 
-class TermsOfUseError(Exception):
+class TermsOfUseError(PyLibreLinkUpError):
     """Raised when the user needs to accept terms of use."""
 
     def __init__(self):
         super().__init__("User needs to accept terms of use. ")
 
 
-class PrivacyPolicyError(Exception):
+class PrivacyPolicyError(PyLibreLinkUpError):
     """Raised when the user needs to accept the privacy policy."""
 
     def __init__(self):
         super().__init__("User needs to accept the privacy policy. ")
+
+
+class EmailVerificationError(PyLibreLinkUpError):
+    """Raised when the user needs to verify their email."""
+
+    def __init__(self):
+        super().__init__("User needs to verify their email. ")

--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -11,6 +11,7 @@ from .exceptions import (
     RedirectError,
     TermsOfUseError,
     PrivacyPolicyError,
+    EmailVerificationError,
 )
 from .models.connection import ConnectionResponse
 from .models.data import Patient
@@ -61,6 +62,8 @@ class PyLibreLinkUp:
                 raise TermsOfUseError()
             case "pp":
                 raise PrivacyPolicyError()
+            case "verifyEmail":
+                raise EmailVerificationError()
 
         try:
             login_response = LoginResponse.model_validate(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,12 @@ def redirect_response_json():
         return json.loads(f.read())
 
 
+@pytest.fixture
+def email_verification_response_json():
+    with open(Path(__file__).parent / "data" / "email_verification_response.json") as f:
+        return json.loads(f.read())
+
+
 @dataclass
 class PyLibreLinkUpClientFixture:
     client: PyLibreLinkUp

--- a/tests/data/email_verification_response.json
+++ b/tests/data/email_verification_response.json
@@ -1,0 +1,22 @@
+{
+  "status": 4,
+  "data": {
+    "step": {
+      "type": "verifyEmail",
+      "componentName": "VerifyEmail",
+      "props": {
+        "email": "test@example.com"
+      }
+    },
+    "user": {
+      "accountType": "pat",
+      "country": "GB",
+      "uiLanguage": ""
+    },
+    "authTicket": {
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjhmZmYzNzk4LTk5ZjgtMTFlZi05MzYyLWY2ZGMwZGI2MTkzNyIsImZpcnN0TmFtZSI6IlJvYiIsImxhc3ROYW1lIjoiQmVyd2ljayIsImNvdW50cnkiOiJHQiIsInJlZ2lvbiI6ImV1MiIsInJvbGUiOiJwYXRpZW50IiwiZW1haWwiOiJsbHUtcHAtdG91QGJlcndpY2stb25saW5lLmNvbSIsImMiOjEsInMiOiJsbHUuYW5kcm9pZCIsImV4cCI6MTczMDY1MTQzMn0.D7W6ZJHmW2ZRmKMOaTyKszmZzYoDzEs4CELvDF6yz0I",
+      "expires": 1730651432,
+      "duration": 3600000
+    }
+  }
+}

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -11,7 +11,7 @@ from pylibrelinkup import (
     TermsOfUseError,
     RedirectError,
 )
-from pylibrelinkup.exceptions import PrivacyPolicyError
+from pylibrelinkup.exceptions import PrivacyPolicyError, EmailVerificationError
 from pylibrelinkup.models.login import (
     LoginResponse,
 )
@@ -119,6 +119,22 @@ def test_authenticate_raises_privacy_policy_error(
     )
 
     with pytest.raises(PrivacyPolicyError):
+        pylibrelinkup_client.client.authenticate()
+
+
+def test_authenticate_raise_email_verification_error(
+    mocked_responses, pylibrelinkup_client, email_verification_response_json
+):
+    """Test that the authenticate method raises an EmailVerificationError, when the user needs to verify their email."""
+
+    mocked_responses.add(
+        responses.POST,
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
+        json=email_verification_response_json,
+        status=200,
+    )
+
+    with pytest.raises(EmailVerificationError):
         pylibrelinkup_client.client.authenticate()
 
 


### PR DESCRIPTION
This pull request adds support for the login response which indicates that the user's email address requires verification. It introduces a new base exception class `PyLibreLinkUpError` and refactors existing exceptions to inherit from it. Additionally, a new exception `EmailVerificationError` is added to handle email verification errors. Corresponding changes are made to the authentication logic and tests to accommodate this new exception.

### Refactoring and New Exception:

* Introduced `PyLibreLinkUpError` as a base class for all custom exceptions in the `pylibrelinkup` module. (`src/pylibrelinkup/exceptions.py`)
* Added a new exception `EmailVerificationError` to handle scenarios where the user needs to verify their email. (`src/pylibrelinkup/exceptions.py`)

### Authentication Logic Update:

* Updated the `authenticate` method to raise `EmailVerificationError` when the authentication response indicates that email verification is required. (`src/pylibrelinkup/pylibrelinkup.py`)

### Test Enhancements:

* Added a new test fixture `email_verification_response_json` to provide mock data for email verification responses. (`tests/conftest.py`)
* Created a new test case to ensure the `authenticate` method raises `EmailVerificationError` when appropriate. (`tests/test_client_authentication.py`)
* Added a new JSON file `email_verification_response.json` containing mock data for email verification responses. (`tests/data/email_verification_response.json`)