### PR TITLE
Relax login response validation

### DIFF
--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -66,11 +66,10 @@ class PyLibreLinkUp:
                 raise EmailVerificationError()
 
         try:
-            login_response = LoginResponse.model_validate(data)
-            self.token = login_response.data.authTicket.token
+            self.token = data["data"]["authTicket"]["token"]
             self.HEADERS.update({"authorization": "Bearer " + self.token})
 
-        except ValidationError:
+        except KeyError:
             raise AuthenticationError("Invalid login credentials")
 
     def get_patients(self) -> list[Patient]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ def mocked_responses():
 
 
 @pytest.fixture
+def login_response_json():
+    with open(Path(__file__).parent / "data" / "login_response.json") as f:
+        return json.loads(f.read())
+
+
+@pytest.fixture
 def graph_response_json():
     with open(Path(__file__).parent / "data" / "graph_response.json") as f:
         return json.loads(f.read())

--- a/tests/data/login_response.json
+++ b/tests/data/login_response.json
@@ -1,0 +1,65 @@
+{
+  "status": 0,
+  "data": {
+    "user": {
+      "id": "xx",
+      "firstName": "xx",
+      "lastName": "xx",
+      "email": "xx",
+      "country": "CA",
+      "uiLanguage": "en",
+      "communicationLanguage": "en",
+      "accountType": "pat",
+      "uom": "0",
+      "dateFormat": "2",
+      "timeFormat": "2",
+      "emailDay": [
+        1
+      ],
+      "system": {
+        "messages": {
+          "appReviewBanner": 1730575099,
+          "firstUsePhoenix": 1730575050,
+          "firstUsePhoenixReportsDataMerged": 1730575050,
+          "lluNewFeatureModal": 1730575069,
+          "lluOnboarding": 1730575088,
+          "lvWebPostRelease": "3.19.10"
+        }
+      },
+      "details": {},
+      "twoFactor": {
+        "primaryMethod": "",
+        "primaryValue": "",
+        "secondaryMethod": "",
+        "secondaryValue": ""
+      },
+      "created": 1730625555,
+      "lastLogin": 1730629766,
+      "programs": {},
+      "dateOfBirth": 29894400,
+      "practices": {},
+      "devices": {},
+      "consents": {
+        "llu": {
+          "policyAccept": 1730575050,
+          "touAccept": 1730575050
+        }
+      }
+    },
+    "messages": {
+      "unread": 0
+    },
+    "notifications": {
+      "unresolved": 0
+    },
+    "authTicket": {
+      "token": "parp",
+      "expires": 1746127527,
+      "duration": 15552000000
+    },
+    "invitations": [
+      "cxxx"
+    ],
+    "trustedDeviceToken": ""
+  }
+}

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -41,17 +41,13 @@ def test_authenticate_raises_error_on_incorrect_login(
 
 
 def test_authenticate_sets_token_on_correct_login(
-    mocked_responses, pylibrelinkup_client
+    mocked_responses, pylibrelinkup_client, login_response_json
 ):
     """Test that the authenticate method sets the token on a successful login."""
-    response = LoginResponseFactory.build()
-    response.data.authTicket.token = "parp"
-    assert isinstance(response, LoginResponse)
-
     mocked_responses.add(
         responses.POST,
         f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
-        json=json.loads(response.model_dump_json()),
+        json=login_response_json,
         status=200,
     )
 


### PR DESCRIPTION
Relax the login response validation when authenticating. Rather than try to validate the entire response, and matching all the variations of those, instead just look for a `token` in the `authTicket` key, and if that's present, we're logged in.