### PR TITLE
chore: Add pre-commit to dev dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.8.0
+    hooks:
+      - id: black
+          # It is recommended to specify the latest version of Python
+          # supported by your project here, or alternatively use
+          # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-dev = ["black", "isort"]
+dev = ["black", "isort", "pre-commit"]
 test = ["pytest", "pytest-cov", "pytest-mock", "polyfactory", "responses"]
 
 [project.urls]


### PR DESCRIPTION
This pull request introduces pre-commit hooks and updates the development dependencies to include `pre-commit`. The changes ensure code consistency and enforce coding standards using `black` and `isort`.

Configuration for pre-commit hooks:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R16): Added configuration for `isort` and `black` hooks with specified versions and Python language version.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R40): Added `pre-commit` to the development dependencies to ensure pre-commit hooks are installed and run.