### PR TITLE
fix: fix mis-indented model definitions

### DIFF
--- a/src/pylibrelinkup/models/data.py
+++ b/src/pylibrelinkup/models/data.py
@@ -118,12 +118,11 @@ class L(BaseModel):
         from_attributes=True,
     )
 
-
-th: int = Field(default=0)
-thmm: float = Field(default=0.0)
-d: int = Field(default=0)
-tl: int = Field(default=0)
-tlmm: float = Field(default=0.0)
+    th: int = Field(default=0)
+    thmm: float = Field(default=0.0)
+    d: int = Field(default=0)
+    tl: int = Field(default=0)
+    tlmm: float = Field(default=0.0)
 
 
 class H(BaseModel):
@@ -133,11 +132,10 @@ class H(BaseModel):
         from_attributes=True,
     )
 
-
-th: int = Field(default=0)
-thmm: float = Field(default=0.0)
-d: int = Field(default=0)
-f: float = Field(default=0.0)
+    th: int = Field(default=0)
+    thmm: float = Field(default=0.0)
+    d: int = Field(default=0)
+    f: float = Field(default=0.0)
 
 
 class Nd(BaseModel):
@@ -147,10 +145,9 @@ class Nd(BaseModel):
         from_attributes=True,
     )
 
-
-i: int = Field(default=0)
-r: int = Field(default=0)
-l: int = Field(default=0)
+    i: int = Field(default=0)
+    r: int = Field(default=0)
+    l: int = Field(default=0)
 
 
 class Std(BaseModel):

--- a/src/pylibrelinkup/models/hardware.py
+++ b/src/pylibrelinkup/models/hardware.py
@@ -16,12 +16,11 @@ class Sensor(BaseModel):
         from_attributes=True,
     )
 
-
-device_id: str = Field(default="")
-sn: str = Field(default="")
-a: int = Field(default=0)
-w: int = Field(default=0)
-pt: int = Field(default=0)
+    device_id: str = Field(default="")
+    sn: str = Field(default="")
+    a: int = Field(default=0)
+    w: int = Field(default=0)
+    pt: int = Field(default=0)
 
 
 class PatientDevice(BaseModel):
@@ -34,15 +33,14 @@ class PatientDevice(BaseModel):
         from_attributes=True,
     )
 
-
-did: str = Field(default="")
-dtid: int = Field(default=0)
-v: str = Field(default="")
-ll: int = Field(default=0)
-hl: int = Field(default=0)
-u: int = Field(default=0)
-fixed_low_alarm_values: FixedLowAlarmValues
-alarms: bool = Field(default=False)
+    did: str = Field(default="")
+    dtid: int = Field(default=0)
+    v: str = Field(default="")
+    ll: int = Field(default=0)
+    hl: int = Field(default=0)
+    u: int = Field(default=0)
+    fixed_low_alarm_values: FixedLowAlarmValues
+    alarms: bool = Field(default=False)
 
 
 class ActiveSensor(BaseModel):
@@ -55,6 +53,5 @@ class ActiveSensor(BaseModel):
         from_attributes=True,
     )
 
-
-sensor: Sensor
-device: PatientDevice
+    sensor: Sensor
+    device: PatientDevice


### PR DESCRIPTION
This pull request includes minor formatting changes to several model classes in the `src/pylibrelinkup/models` directory. These changes fix mis-indented lines in the model class definitions.
