### PR TITLE
Handle patient not found errors in graph API responses

### DIFF
--- a/src/pylibrelinkup/exceptions.py
+++ b/src/pylibrelinkup/exceptions.py
@@ -42,3 +42,10 @@ class EmailVerificationError(PyLibreLinkUpError):
 
     def __init__(self):
         super().__init__("User needs to verify their email. ")
+
+
+class PatientNotFoundError(PyLibreLinkUpError):
+    """Raised when a patient with the provided patient_id is not found."""
+
+    def __init__(self):
+        super().__init__("Patient not found")

--- a/tests/data/patient_not_found.json
+++ b/tests/data/patient_not_found.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "message": "couldNotLoadPatient"
+  },
+  "status": 4
+}

--- a/tests/test_client_graph.py
+++ b/tests/test_client_graph.py
@@ -3,7 +3,7 @@ from uuid import UUID
 import pytest
 import responses
 
-from pylibrelinkup import AuthenticationError
+from pylibrelinkup import AuthenticationError, PatientNotFoundError
 from pylibrelinkup.models.data import GlucoseMeasurement
 from tests.conftest import graph_response_json
 from tests.factories import PatientFactory
@@ -188,3 +188,22 @@ def test_graph_response_no_u_returns_graph_response(
         result[0].value_in_mg_per_dl
         == graph_response_no_u_json["data"]["graphData"][0]["ValueInMgPerDl"]
     )
+
+
+def test_graph_response_patient_id_not_found_raises_patient_not_found_error(
+    mocked_responses, pylibrelinkup_client, get_response_json
+):
+    """Test that the read method raises PatientNotFoundError for a patient not found."""
+    patient_id = UUID("12345678-1234-5678-1234-567812345678")
+
+    mocked_responses.add(
+        responses.GET,
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
+        json=get_response_json("terms_of_use_response.json"),
+        status=200,
+    )
+
+    pylibrelinkup_client.client.token = "not_a_token"
+
+    with pytest.raises(PatientNotFoundError, match="Patient not found"):
+        pylibrelinkup_client.client.graph(patient_id)


### PR DESCRIPTION
This pull request introduces a new exception for handling cases where a patient is not found, refactors the API response models, and adds corresponding tests to ensure the new functionality works as expected.

### New Exception Handling:
* Added `PatientNotFoundError` exception in `src/pylibrelinkup/exceptions.py` to handle cases where a patient with the provided `patient_id` is not found.

### API Response Model Refactoring:
* Introduced `APIResponse` as a base model for API responses in `src/pylibrelinkup/models/connection.py`. This includes a new `validate_api_response` method to handle validation and raise the `PatientNotFoundError` when appropriate.
* Refactored `GraphResponse` and `LogbookResponse` to inherit from `APIResponse` and removed redundant code.

### Imports and Dependencies:
* Updated imports in `src/pylibrelinkup/models/connection.py` to include `PatientNotFoundError` and necessary Pydantic validators. [[1]](diffhunk://#diff-5dcdd36113dc62abf2d50a35faecbf378a2c3a62110898fe840af05cc29aa71aR2-R6) [[2]](diffhunk://#diff-5dcdd36113dc62abf2d50a35faecbf378a2c3a62110898fe840af05cc29aa71aR15-R16)

### Tests:
* Added a new test JSON file `tests/data/patient_not_found.json` to simulate the patient not found scenario.
* Added tests to ensure that `PatientNotFoundError` is raised correctly in various client methods (`graph`, `latest`, `logbook`, and `read`). [[1]](diffhunk://#diff-e95a683bd79e8b1b2fdd218833229d6a80a444cc8822d823ef501a20c9d98678R191-R209) [[2]](diffhunk://#diff-eeb9d88b617dbcbd7b1f14a6b28c6e9a41442b818eee29274014aa057e374270R170-R190) [[3]](diffhunk://#diff-99a9495aab48048c9e9576d6a3235f63deb7d1cc17dafe5d6149ce95b443479dR117-R135) [[4]](diffhunk://#diff-d959ecc36c943340fc7d936fa19a0a868a8d262e38a3fece9fc0a9b0b9a4f0caR173-R191)