### PR TITLE
Handle `realWorldEvidence` in login response payload

### DIFF
--- a/src/pylibrelinkup/models/login.py
+++ b/src/pylibrelinkup/models/login.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 __all__ = [
     "Llu",
@@ -26,8 +26,21 @@ class Llu(BaseModel):
     touAccept: int = Field(default=0)
 
 
+class HistoryItem(BaseModel):
+    policyAccept: int = Field(default=0)
+    declined: bool | None = None
+
+
+class RealWorldEvidence(BaseModel):
+    policyAccept: int = Field(default=0)
+    declined: bool = False
+    touAccept: int = Field(default=0)
+    history: List[HistoryItem] = []
+
+
 class Consents(BaseModel):
-    llu: Llu
+    llu: Llu = Llu()
+    realWorldEvidence: RealWorldEvidence = RealWorldEvidence()
 
 
 class SystemMessages(BaseModel):
@@ -87,6 +100,10 @@ class Data(BaseModel):
     notifications: Notifications
     authTicket: AuthTicket
     invitations: List[str]
+
+    @field_validator("invitations", mode="before")
+    def coerce_null_to_empty_list(cls, v):
+        return v if v is not None else []
 
 
 class LoginResponse(BaseModel):

--- a/tests/data/realworldevidence_consent_response.json
+++ b/tests/data/realworldevidence_consent_response.json
@@ -1,0 +1,82 @@
+{
+  "status": 0,
+  "data": {
+    "user": {
+      "id": "<Id>",
+      "firstName": "<name>",
+      "lastName": "<name>",
+      "email": "<email>",
+      "country": "GB",
+      "uiLanguage": "en-GB",
+      "communicationLanguage": "en-GB",
+      "accountType": "pat",
+      "uom": "0",
+      "dateFormat": "2",
+      "timeFormat": "2",
+      "emailDay": [
+        1
+      ],
+      "system": {
+        "messages": {
+          "appReviewBanner": 1704319358,
+          "firstUsePhoenix": 1704288789,
+          "firstUsePhoenixReportsDataMerged": 1704288789,
+          "lluGettingStartedBanner": 1704319384,
+          "lluNewFeatureModal": 1704319219,
+          "lvWebPostRelease": "3.16.19",
+          "streamingTourMandatory": 1704319433
+        }
+      },
+      "details": {},
+      "twoFactor": {
+        "primaryMethod": "phone",
+        "primaryValue": "<number>",
+        "secondaryMethod": "email",
+        "secondaryValue": "<email>"
+      },
+      "created": 1704288789,
+      "lastLogin": 1737891119,
+      "programs": {},
+      "dateOfBirth": 29894400,
+      "practices": {},
+      "devices": {
+        "<device id>": {
+          "id": "<device id>",
+          "nickname": "",
+          "sn": "<sn>",
+          "type": 40066,
+          "uploadDate": 1737891498
+        }
+      },
+      "consents": {
+        "realWorldEvidence": {
+          "policyAccept": 1737890544,
+          "declined": true,
+          "touAccept": 0,
+          "history": [
+            {
+              "policyAccept": 1704288796
+            },
+            {
+              "policyAccept": 1737890544,
+              "declined": true
+            }
+          ]
+        }
+      }
+    },
+    "messages": {
+      "unread": 0
+    },
+    "notifications": {
+      "unresolved": 0
+    },
+    "authTicket": {
+      "token": "parp",
+      "expires": 1753443551,
+      "duration": 15552000000
+    },
+    "invitations": null,
+    "trustedDeviceToken": ""
+  }
+}

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -142,3 +142,18 @@ def test_redirection_response_raises_redirect_error(
 
     with pytest.raises(RedirectError):
         pylibrelinkup_client.client.authenticate()
+
+
+def test_realworldevidence_consent_in_login_response(
+    mocked_responses, pylibrelinkup_client, get_response_json
+):
+    """Test that the authenticate method raises an error when the user needs to accept the real world evidence consent."""
+
+    mocked_responses.add(
+        responses.POST,
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
+        json=get_response_json("realworldevidence_consent_response.json"),
+        status=200,
+    )
+
+    pylibrelinkup_client.client.authenticate()


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `pylibrelinkup` library, particularly focusing on the `login` model and its associated test cases. The most important changes include adding new models, introducing a field validator, and expanding the test coverage.

### Enhancements to Models and Validation:

* [`src/pylibrelinkup/models/login.py`](diffhunk://#diff-cc7d6f3300a63537d4225a35b6fd5ed2f529377f81aa4d1eb06d303cea2da789R29-R43): Added new classes `HistoryItem` and `RealWorldEvidence` to handle additional consent data. Updated the `Consents` class to include a new `realWorldEvidence` field.
* [`src/pylibrelinkup/models/login.py`](diffhunk://#diff-cc7d6f3300a63537d4225a35b6fd5ed2f529377f81aa4d1eb06d303cea2da789R104-R107): Introduced a `field_validator` for the `invitations` field in the `Data` class to coerce null values to an empty list.

### Error Handling:

* [`src/pylibrelinkup/pylibrelinkup.py`](diffhunk://#diff-21553e1facba3cddbfdb698e185b0e110e532ebb3682f0001a1c37a00243ed35R145): Improved error handling in the `authenticate` method by re-raising `ValidationError` before raising `AuthenticationError`.

### Test Coverage:

* [`tests/data/realworldevidence_consent_response.json`](diffhunk://#diff-51b66304cc7848b8f8bb589e510666b60c6ea0aa6b3e09c50f6c9066b448935eR1-R82): Added a new JSON file to simulate a login response requiring real-world evidence consent.
* [`tests/test_client_authentication.py`](diffhunk://#diff-09e2c6d68df01bcd8122872202968c8734eacb33fe60c8f243a3ba861cd0159cR145-R159): Added a new test `test_realworldevidence_consent_in_login_response` to verify the handling of login responses that include real-world evidence consent requirements.

Fixes #53 