### PR TITLE
feat: update latest glucose measurement model to include trend

### DIFF
--- a/src/pylibrelinkup/models/connection.py
+++ b/src/pylibrelinkup/models/connection.py
@@ -7,7 +7,7 @@ from pydantic.functional_validators import ModelWrapValidatorHandler
 
 from .base import ConfigBaseModel
 from .config import AlarmRules
-from .data import GlucoseMeasurement
+from .data import GlucoseMeasurement, GlucoseMeasurementWithTrend
 from .hardware import ActiveSensor, PatientDevice, Sensor
 
 __all__ = ["GraphResponse", "LogbookResponse"]
@@ -29,7 +29,7 @@ class Connection(ConfigBaseModel):
     uom: int = Field(default=0)
     sensor: Sensor
     alarm_rules: AlarmRules
-    glucose_measurement: GlucoseMeasurement
+    glucose_measurement: GlucoseMeasurementWithTrend = Field(alias="glucoseMeasurement")
     glucose_item: GlucoseMeasurement
     glucose_alarm: None
     patient_device: PatientDevice

--- a/src/pylibrelinkup/models/data.py
+++ b/src/pylibrelinkup/models/data.py
@@ -10,7 +10,7 @@ __all__ = [
     "Patient",
     "Trend",
     "GlucoseMeasurement",
-    "GlucoseMeasurementTrend",
+    "GlucoseMeasurementWithTrend",
     "F",
     "L",
     "H",
@@ -42,6 +42,17 @@ class Trend(IntEnum):
     STABLE = 3
     UP_SLOW = 4
     UP_FAST = 5
+
+    @property
+    def indicator(self) -> str:
+        arrow_map: dict[Trend, str] = {
+            Trend.DOWN_FAST: "↓",
+            Trend.DOWN_SLOW: "↘",
+            Trend.STABLE: "→",
+            Trend.UP_SLOW: "↗",
+            Trend.UP_FAST: "↑",
+        }
+        return arrow_map[self]
 
 
 class GlucoseMeasurement(ConfigBaseModel):
@@ -82,13 +93,6 @@ class GlucoseMeasurement(ConfigBaseModel):
             # factory_timestamp is in UTC
             datetime_value = datetime_value.replace(tzinfo=UTC)
         return datetime_value
-
-
-class GlucoseMeasurementTrend(GlucoseMeasurement):
-    trend_arrow: Trend
-
-    def __str__(self):
-        return f"{super().__str__()} {self.trend_arrow}"
 
 
 class F(ConfigBaseModel):
@@ -132,3 +136,7 @@ class Std(ConfigBaseModel):
     """Std class to store Std data."""
 
     sd: bool | None = Field(default=None)
+
+
+class GlucoseMeasurementWithTrend(GlucoseMeasurement):
+    trend: Trend = Field(default=Trend.STABLE)

--- a/tests/test_client_latest.py
+++ b/tests/test_client_latest.py
@@ -4,7 +4,7 @@ import pytest
 import responses
 
 from pylibrelinkup import AuthenticationError, PatientNotFoundError
-from pylibrelinkup.models.data import GlucoseMeasurement
+from pylibrelinkup.models.data import GlucoseMeasurementWithTrend, Trend
 from tests.conftest import graph_response_json
 from tests.factories import PatientFactory
 
@@ -34,7 +34,7 @@ def test_latest_returns_glucose_measurement_for_valid_uuid(
 
     result = pylibrelinkup_client.client.latest(patient_id)
 
-    assert isinstance(result, GlucoseMeasurement)
+    assert isinstance(result, GlucoseMeasurementWithTrend)
 
     assert (
         result.value_in_mg_per_dl
@@ -42,6 +42,7 @@ def test_latest_returns_glucose_measurement_for_valid_uuid(
             "ValueInMgPerDl"
         ]
     )
+    assert result.trend == Trend.STABLE
 
 
 def test_latest_returns_glucose_measurement_for_valid_patient(
@@ -61,7 +62,7 @@ def test_latest_returns_glucose_measurement_for_valid_patient(
 
     result = pylibrelinkup_client.client.latest(patient)
 
-    assert isinstance(result, GlucoseMeasurement)
+    assert isinstance(result, GlucoseMeasurementWithTrend)
 
     assert (
         result.value_in_mg_per_dl
@@ -69,6 +70,7 @@ def test_latest_returns_glucose_measurement_for_valid_patient(
             "ValueInMgPerDl"
         ]
     )
+    assert result.trend == Trend.STABLE
 
 
 def test_latest_returns_glucose_measurement_for_valid_string(
@@ -88,7 +90,7 @@ def test_latest_returns_glucose_measurement_for_valid_string(
 
     result = pylibrelinkup_client.client.latest(patient_id)
 
-    assert isinstance(result, GlucoseMeasurement)
+    assert isinstance(result, GlucoseMeasurementWithTrend)
 
     assert (
         result.value_in_mg_per_dl
@@ -96,6 +98,7 @@ def test_latest_returns_glucose_measurement_for_valid_string(
             "ValueInMgPerDl"
         ]
     )
+    assert result.trend == Trend.STABLE
 
 
 def test_latest_raises_value_error_for_invalid_uuid_string(
@@ -133,7 +136,7 @@ def test_latest_response_no_sd_returns_glucose_measurement(
 
     result = pylibrelinkup_client.client.latest(patient_id)
 
-    assert isinstance(result, GlucoseMeasurement)
+    assert isinstance(result, GlucoseMeasurementWithTrend)
 
     assert (
         result.value_in_mg_per_dl
@@ -141,6 +144,7 @@ def test_latest_response_no_sd_returns_glucose_measurement(
             "ValueInMgPerDl"
         ]
     )
+    assert result.trend == Trend.STABLE
 
 
 def test_latest_response_no_alarm_rules_c_returns_glucose_measurement(
@@ -160,13 +164,14 @@ def test_latest_response_no_alarm_rules_c_returns_glucose_measurement(
 
     result = pylibrelinkup_client.client.latest(patient_id)
 
-    assert isinstance(result, GlucoseMeasurement)
+    assert isinstance(result, GlucoseMeasurementWithTrend)
     assert (
         result.value_in_mg_per_dl
         == graph_response_no_alarm_rules_c_json["data"]["connection"][
             "glucoseMeasurement"
         ]["ValueInMgPerDl"]
     )
+    assert result.trend == Trend.STABLE
 
 
 def test_latest_patient_not_found_raises_patient_not_found_error(


### PR DESCRIPTION
This pull request includes several changes to the `pylibrelinkup` package, specifically focusing on the `connection` and `data` models. The primary goal is to introduce a new `GlucoseMeasurementWithTrend` class and add a property to the `Trend` class for better data representation.

### Changes to Models:

* [`src/pylibrelinkup/models/connection.py`](diffhunk://#diff-5dcdd36113dc62abf2d50a35faecbf378a2c3a62110898fe840af05cc29aa71aL32-R32): Updated the `Connection` class to use `GlucoseMeasurementWithTrend` instead of `GlucoseMeasurement`. This change includes setting an alias for the `glucoseMeasurement` field.
* [`src/pylibrelinkup/models/data.py`](diffhunk://#diff-44ec3d257dc038d17668abdc1440bc9b3447e09b6f840ce7359b269bedd47417L13-R13): Renamed `GlucoseMeasurementTrend` to `GlucoseMeasurementWithTrend` and added a default `Trend` value to the new class. [[1]](diffhunk://#diff-44ec3d257dc038d17668abdc1440bc9b3447e09b6f840ce7359b269bedd47417L13-R13) [[2]](diffhunk://#diff-44ec3d257dc038d17668abdc1440bc9b3447e09b6f840ce7359b269bedd47417R139-R142)

### Enhancements to Trend Representation:

* [`src/pylibrelinkup/models/data.py`](diffhunk://#diff-44ec3d257dc038d17668abdc1440bc9b3447e09b6f840ce7359b269bedd47417R46-R56): Added an `indicator` property to the `Trend` class that returns a string representation of the trend direction using arrows.