### PR TITLE
fix: update latest method return type to GlucoseMeasurementWithTrend

### DIFF
--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -24,7 +24,7 @@ from .exceptions import (
     TermsOfUseError,
 )
 from .models.connection import GraphResponse, LogbookResponse
-from .models.data import GlucoseMeasurement, Patient
+from .models.data import GlucoseMeasurement, GlucoseMeasurementWithTrend, Patient
 from .models.login import LoginArgs, LoginResponse
 from .utilities import coerce_patient_id
 
@@ -197,12 +197,14 @@ class PyLibreLinkUp:
         return GraphResponse.model_validate(response_json).history
 
     @authenticated
-    def latest(self, patient_identifier: PatientIdentifier) -> GlucoseMeasurement:
+    def latest(
+        self, patient_identifier: PatientIdentifier
+    ) -> GlucoseMeasurementWithTrend:
         """Requests and returns the most recent glucose measurement
 
         :param patient_identifier: PatientIdentifier: The identifier of the patient.
         :return: The most recent glucose measurement.
-        :rtype: GlucoseMeasurement
+        :rtype: GlucoseMeasurementWithTrend
         """
         patient_id = coerce_patient_id(patient_identifier)
 


### PR DESCRIPTION
This pull request includes changes to the `pylibrelinkup` module, specifically enhancing the handling of glucose measurements. The most important changes include updating the return type hint of the `latest()` method.

Enhancements to glucose measurement handling:

* [`src/pylibrelinkup/pylibrelinkup.py`](diffhunk://#diff-21553e1facba3cddbfdb698e185b0e110e532ebb3682f0001a1c37a00243ed35L27-R27): Added `GlucoseMeasurementWithTrend` to the imports from `.models.data`.
* [`src/pylibrelinkup/pylibrelinkup.py`](diffhunk://#diff-21553e1facba3cddbfdb698e185b0e110e532ebb3682f0001a1c37a00243ed35L200-R202): Updated the `latest` method to return `GlucoseMeasurementWithTrend` instead of `GlucoseMeasurement`.