### PR TITLE
Handle LLU HTTP 429 rate limit errors in API calls

### DIFF
--- a/src/pylibrelinkup/exceptions.py
+++ b/src/pylibrelinkup/exceptions.py
@@ -49,3 +49,24 @@ class PatientNotFoundError(PyLibreLinkUpError):
 
     def __init__(self):
         super().__init__("Patient not found")
+
+
+class LLUAPIError(PyLibreLinkUpError):
+    """Raised when the LibreLinkUp API returns an error."""
+
+    def __init__(self, response_code: int, message: str):
+        self.response_code = response_code
+        exception_message = f"LLU API returned error {response_code}: {message}"
+        super().__init__(exception_message)
+
+
+class LLAAPIRateLimitError(LLUAPIError):
+    """Raised when the LibreLinkUp API returns a rate limit error."""
+
+    retry_after: int | None
+
+    def __init__(
+        self, response_code: int, message: str, retry_after: int | None = None
+    ):
+        self.retry_after = retry_after
+        super().__init__(response_code, message)

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -1,0 +1,81 @@
+import pytest
+import responses
+from requests import HTTPError
+
+from pylibrelinkup import LLAAPIRateLimitError
+from tests.conftest import pylibrelinkup_client
+
+
+def test_call_api_with_rate_limit_and_numeric_retry_after(
+    mocked_responses, pylibrelinkup_client
+):
+    """Test that 429 responses with numeric Retry-After raise LLAAPIRateLimitError with correct retry value."""
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    mocked_responses.add(responses.GET, url, status=429, headers={"Retry-After": "30"})
+
+    pylibrelinkup_client.client.token = "test_token"
+
+    with pytest.raises(LLAAPIRateLimitError) as exc_info:
+        pylibrelinkup_client.client._call_api(url)
+
+    assert exc_info.value.response_code == 429
+    assert exc_info.value.retry_after == 30
+    assert "Too many requests" in str(exc_info.value)
+
+
+def test_call_api_with_rate_limit_and_non_numeric_retry_after(
+    mocked_responses, pylibrelinkup_client
+):
+    """Test that 429 responses with non-numeric Retry-After set retry_after to None."""
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    mocked_responses.add(
+        responses.GET, url, status=429, headers={"Retry-After": "soon"}
+    )
+
+    pylibrelinkup_client.client.token = "test_token"
+
+    with pytest.raises(LLAAPIRateLimitError) as exc_info:
+        pylibrelinkup_client.client._call_api(url)
+
+    assert exc_info.value.retry_after is None
+
+
+def test_call_api_with_rate_limit_and_missing_retry_after(
+    mocked_responses, pylibrelinkup_client
+):
+    """Test that 429 responses without Retry-After set retry_after to None."""
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    mocked_responses.add(responses.GET, url, status=429)
+
+    pylibrelinkup_client.client.token = "test_token"
+
+    with pytest.raises(LLAAPIRateLimitError) as exc_info:
+        pylibrelinkup_client.client._call_api(url)
+
+    assert exc_info.value.retry_after is None
+
+
+def test_call_api_with_other_http_errors(mocked_responses, pylibrelinkup_client):
+    """Test that non-429 HTTP errors are re-raised as HTTPError."""
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    mocked_responses.add(responses.GET, url, status=401)
+
+    pylibrelinkup_client.client.token = "test_token"
+
+    with pytest.raises(HTTPError) as exc_info:
+        pylibrelinkup_client.client._call_api(url)
+
+    assert exc_info.value.response.status_code == 401
+
+
+def test_call_api_successful_response(mocked_responses, pylibrelinkup_client):
+    """Test that successful API calls return JSON data."""
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    expected_data = {"test": "data"}
+
+    mocked_responses.add(responses.GET, url, json=expected_data, status=200)
+
+    pylibrelinkup_client.client.token = "test_token"
+    result = pylibrelinkup_client.client._call_api(url)
+
+    assert result == expected_data


### PR DESCRIPTION
This pull request introduces new error handling for the LibreLinkUp API and adds comprehensive tests for these changes. The main updates include the addition of new exception classes to handle API errors and modifications to the `_call_api` method to raise these exceptions appropriately. Additionally, new tests have been added to verify the correct behavior of the error handling logic.

### Error Handling Enhancements:

* [`src/pylibrelinkup/exceptions.py`](diffhunk://#diff-5ae21685652f994eb0e6e068795f79fd99b292ffd95dcc3e7355772382abde25R52-R72): Added `LLUAPIError` for general API errors and `LLAAPIRateLimitError` for handling rate limit errors.
* [`src/pylibrelinkup/pylibrelinkup.py`](diffhunk://#diff-21553e1facba3cddbfdb698e185b0e110e532ebb3682f0001a1c37a00243ed35R80-R91): Updated `_call_api` method to raise `LLAAPIRateLimitError` when a 429 status code is encountered and to re-raise other HTTP errors.

### Test Additions:

* [`tests/test_client_api.py`](diffhunk://#diff-7e7b34922899eabe3496f4561119e297a2a329d6119d8ec17e22fad174dc9f7eR1-R81): Added tests to verify that the `_call_api` method correctly raises `LLAAPIRateLimitError` for 429 responses with numeric, non-numeric, and missing `Retry-After` headers, re-raises other HTTP errors, and successfully returns JSON data for successful responses.

### Import Adjustments:

* [`src/pylibrelinkup/pylibrelinkup.py`](diffhunk://#diff-21553e1facba3cddbfdb698e185b0e110e532ebb3682f0001a1c37a00243ed35R15-R17): Imported `HTTPError` and `LLAAPIRateLimitError` to support the new error handling logic.