### PR TITLE
fix: update trend alias in GlucoseMeasurementWithTrend and adjust tests

### DIFF
--- a/src/pylibrelinkup/models/data.py
+++ b/src/pylibrelinkup/models/data.py
@@ -139,4 +139,4 @@ class Std(ConfigBaseModel):
 
 
 class GlucoseMeasurementWithTrend(GlucoseMeasurement):
-    trend: Trend = Field(default=Trend.STABLE)
+    trend: Trend = Field(default=Trend.STABLE, alias="TrendArrow")

--- a/tests/data/graph_response.json
+++ b/tests/data/graph_response.json
@@ -58,7 +58,7 @@
         "Timestamp": "5/21/2022 3:38:50 PM",
         "type": 1,
         "ValueInMgPerDl": 91,
-        "TrendArrow": 3,
+        "TrendArrow": 1,
         "TrendMessage": null,
         "MeasurementColor": 1,
         "GlucoseUnits": 1,

--- a/tests/test_client_latest.py
+++ b/tests/test_client_latest.py
@@ -42,7 +42,7 @@ def test_latest_returns_glucose_measurement_for_valid_uuid(
             "ValueInMgPerDl"
         ]
     )
-    assert result.trend == Trend.STABLE
+    assert result.trend == Trend.DOWN_FAST
 
 
 def test_latest_returns_glucose_measurement_for_valid_patient(
@@ -70,7 +70,7 @@ def test_latest_returns_glucose_measurement_for_valid_patient(
             "ValueInMgPerDl"
         ]
     )
-    assert result.trend == Trend.STABLE
+    assert result.trend == Trend.DOWN_FAST
 
 
 def test_latest_returns_glucose_measurement_for_valid_string(
@@ -98,7 +98,7 @@ def test_latest_returns_glucose_measurement_for_valid_string(
             "ValueInMgPerDl"
         ]
     )
-    assert result.trend == Trend.STABLE
+    assert result.trend == Trend.DOWN_FAST
 
 
 def test_latest_raises_value_error_for_invalid_uuid_string(


### PR DESCRIPTION
This pull request includes changes to the `src/pylibrelinkup/models/data.py` and associated test files to update the handling of glucose measurement trends. The changes involve modifying the alias for the `trend` field and updating test cases to reflect the new trend values. This is to address an issue where the `trend` property of the latest glucose measurement was always reported as `3: STABLE`

Updates to glucose measurement trends:

* [`src/pylibrelinkup/models/data.py`](diffhunk://#diff-44ec3d257dc038d17668abdc1440bc9b3447e09b6f840ce7359b269bedd47417L142-R142): Changed the alias for the `trend` field in the `GlucoseMeasurementWithTrend` class to "TrendArrow".

Updates to test cases:

* [`tests/data/graph_response.json`](diffhunk://#diff-f1fb63c8d6916ce69d9082c440f2f6b4763fbc43f22bc7a723ed0196e07dc59eL61-R61): Modified the `TrendArrow` value from 3 to 1 to match the new trend values.
* [`tests/test_client_latest.py`](diffhunk://#diff-eeb9d88b617dbcbd7b1f14a6b28c6e9a41442b818eee29274014aa057e374270L45-R45): Updated the `test_latest_returns_glucose_measurement_for_valid_uuid`, `test_latest_returns_glucose_measurement_for_valid_patient`, and `test_latest_returns_glucose_measurement_for_valid_string` methods to assert that the `trend` is `Trend.DOWN_FAST` instead of `Trend.STABLE`. [[1]](diffhunk://#diff-eeb9d88b617dbcbd7b1f14a6b28c6e9a41442b818eee29274014aa057e374270L45-R45) [[2]](diffhunk://#diff-eeb9d88b617dbcbd7b1f14a6b28c6e9a41442b818eee29274014aa057e374270L73-R73) [[3]](diffhunk://#diff-eeb9d88b617dbcbd7b1f14a6b28c6e9a41442b818eee29274014aa057e374270L101-R101)