### PR TITLE
Handle None values for list fields in API responses

### DIFF
--- a/src/pylibrelinkup/models/base.py
+++ b/src/pylibrelinkup/models/base.py
@@ -1,9 +1,22 @@
-from pydantic import BaseModel, ConfigDict
+from typing import get_origin
+
+from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.alias_generators import to_camel
 
 
 class ConfigBaseModel(BaseModel):
-    """Base class for all models. Provides common configuration."""
+    """Base class for all models. Provides common configuration.
+
+    This base class automatically handles None values for list-type fields
+    by converting them to empty lists during validation. This prevents
+    ValidationErrors when the API returns None for fields expecting lists.
+
+    Configuration:
+        - Strip whitespace from strings
+        - Generate camelCase aliases for fields
+        - Allow population by field name or alias
+        - Enable attribute-based initialization
+    """
 
     model_config = ConfigDict(
         str_strip_whitespace=True,
@@ -11,3 +24,34 @@ class ConfigBaseModel(BaseModel):
         populate_by_name=True,
         from_attributes=True,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def preprocess_data(cls, data):
+        """Preprocess input data before validation.
+
+        This validator runs before Pydantic's field validation and applies
+        transformations to the input data to handle API inconsistencies and
+        ensure consistent data structures.
+
+        Current transformations:
+            - List-type fields: Converts None values to empty lists
+
+        Args:
+            data: The input data dictionary (or other value) to validate
+
+        Returns:
+            The modified data dictionary with transformations applied,
+            or the original data if not a dict
+        """
+        if not isinstance(data, dict):
+            return data
+
+        for field_name, field_info in cls.model_fields.items():
+            if field_name in data and data[field_name] is None:
+                # Check if the field type is a list
+                origin = get_origin(field_info.annotation)
+                if origin is list:
+                    data[field_name] = []
+
+        return data

--- a/src/pylibrelinkup/models/login.py
+++ b/src/pylibrelinkup/models/login.py
@@ -1,6 +1,8 @@
 from typing import List
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import Field
+
+from .base import ConfigBaseModel
 
 __all__ = [
     "Llu",
@@ -21,29 +23,29 @@ __all__ = [
 ]
 
 
-class Llu(BaseModel):
+class Llu(ConfigBaseModel):
     policyAccept: int = Field(default=0)
     touAccept: int = Field(default=0)
 
 
-class HistoryItem(BaseModel):
+class HistoryItem(ConfigBaseModel):
     policyAccept: int = Field(default=0)
     declined: bool | None = None
 
 
-class RealWorldEvidence(BaseModel):
+class RealWorldEvidence(ConfigBaseModel):
     policyAccept: int = Field(default=0)
     declined: bool = False
     touAccept: int = Field(default=0)
     history: List[HistoryItem] = []
 
 
-class Consents(BaseModel):
+class Consents(ConfigBaseModel):
     llu: Llu = Llu()
     realWorldEvidence: RealWorldEvidence = RealWorldEvidence()
 
 
-class SystemMessages(BaseModel):
+class SystemMessages(ConfigBaseModel):
     firstUsePhoenix: int = Field(default=0)
     firstUsePhoenixReportsDataMerged: int = Field(default=0)
     lluGettingStartedBanner: int = Field(default=0)
@@ -52,11 +54,11 @@ class SystemMessages(BaseModel):
     lvWebPostRelease: str = Field(default="")
 
 
-class System(BaseModel):
+class System(ConfigBaseModel):
     messages: SystemMessages
 
 
-class User(BaseModel):
+class User(ConfigBaseModel):
     id: str = Field(default="")
     firstName: str = Field(default="")
     lastName: str = Field(default="")
@@ -80,56 +82,52 @@ class User(BaseModel):
     consents: Consents
 
 
-class Notifications(BaseModel):
+class Notifications(ConfigBaseModel):
     unresolved: int = Field(default=0)
 
 
-class DataMessages(BaseModel):
+class DataMessages(ConfigBaseModel):
     unread: int = Field(default=0)
 
 
-class AuthTicket(BaseModel):
+class AuthTicket(ConfigBaseModel):
     token: str = Field(default="")
     expires: int = Field(default=0)
     duration: int = Field(default=0)
 
 
-class Data(BaseModel):
+class Data(ConfigBaseModel):
     user: User
     messages: DataMessages
     notifications: Notifications
     authTicket: AuthTicket
     invitations: List[str]
 
-    @field_validator("invitations", mode="before")
-    def coerce_null_to_empty_list(cls, v):
-        return v if v is not None else []
 
-
-class LoginResponse(BaseModel):
+class LoginResponse(ConfigBaseModel):
     status: int = Field(default=0)
     data: Data
 
 
-class ErrorMessage(BaseModel):
+class ErrorMessage(ConfigBaseModel):
     message: str = Field(default="")
 
 
-class LoginResponseUnauthenticated(BaseModel):
+class LoginResponseUnauthenticated(ConfigBaseModel):
     status: int = Field(default=0)
     error: ErrorMessage
 
 
-class LoginRedirectData(BaseModel):
+class LoginRedirectData(ConfigBaseModel):
     redirect: bool = Field(default=False)
     region: str = Field(default="")
 
 
-class LoginRedirectResponse(BaseModel):
+class LoginRedirectResponse(ConfigBaseModel):
     status: int = Field(default=0)
     data: LoginRedirectData
 
 
-class LoginArgs(BaseModel):
+class LoginArgs(ConfigBaseModel):
     email: str = Field(default="")
     password: str = Field(default="")

--- a/tests/data/login_response_null_emailday.json
+++ b/tests/data/login_response_null_emailday.json
@@ -1,0 +1,63 @@
+{
+  "status": 0,
+  "data": {
+    "user": {
+      "id": "xx",
+      "firstName": "xx",
+      "lastName": "xx",
+      "email": "xx",
+      "country": "CA",
+      "uiLanguage": "en",
+      "communicationLanguage": "en",
+      "accountType": "pat",
+      "uom": "0",
+      "dateFormat": "2",
+      "timeFormat": "2",
+      "emailDay": null,
+      "system": {
+        "messages": {
+          "appReviewBanner": 1730575099,
+          "firstUsePhoenix": 1730575050,
+          "firstUsePhoenixReportsDataMerged": 1730575050,
+          "lluNewFeatureModal": 1730575069,
+          "lluOnboarding": 1730575088,
+          "lvWebPostRelease": "3.19.10"
+        }
+      },
+      "details": {},
+      "twoFactor": {
+        "primaryMethod": "",
+        "primaryValue": "",
+        "secondaryMethod": "",
+        "secondaryValue": ""
+      },
+      "created": 1730625555,
+      "lastLogin": 1730629766,
+      "programs": {},
+      "dateOfBirth": 29894400,
+      "practices": {},
+      "devices": {},
+      "consents": {
+        "llu": {
+          "policyAccept": 1730575050,
+          "touAccept": 1730575050
+        }
+      }
+    },
+    "messages": {
+      "unread": 0
+    },
+    "notifications": {
+      "unresolved": 0
+    },
+    "authTicket": {
+      "token": "parp",
+      "expires": 1746127527,
+      "duration": 15552000000
+    },
+    "invitations": [
+      "cxxx"
+    ],
+    "trustedDeviceToken": ""
+  }
+}

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -157,3 +157,26 @@ def test_realworldevidence_consent_in_login_response(
     )
 
     pylibrelinkup_client.client.authenticate()
+
+
+def test_authenticate_handles_null_emailday(
+    mocked_responses, pylibrelinkup_client, get_response_json
+):
+    """Test that the authenticate method handles None emailDay field correctly.
+
+    Some API responses return None for the emailDay field instead of a list.
+    The generic list validator in ConfigBaseModel should automatically convert
+    None to an empty list, preventing ValidationErrors.
+    """
+    mocked_responses.add(
+        responses.POST,
+        f"{pylibrelinkup_client.api_url.value}/llu/auth/login",
+        json=get_response_json("login_response_null_emailday.json"),
+        status=200,
+    )
+
+    # Should not raise ValidationError
+    pylibrelinkup_client.client.authenticate()
+
+    # Verify authentication succeeded
+    assert pylibrelinkup_client.client.token == "parp"


### PR DESCRIPTION
This pull request fixes a ValidationError that occurs when the LibreLinkUp API returns `None` for list-type fields instead of an empty list. This issue has been observed in API responses from certain regions (e.g., Swedish responses returning `emailDay: null`).

# Problem

When the API returns `None` for fields expecting a list (such as `User.emailDay`), Pydantic raises a ValidationError

# Solution

This PR adds a generic model validator to ConfigBaseModel that automatically converts None values to empty lists for all list-type fields before Pydantic validation runs. This provides:

- Automatic handling of API inconsistencies across all models
- Backward compatibility - existing functionality remains unchanged
- Future-proof - applies to any list field in models inheriting from ConfigBaseModel

# Changes

- Enhancement to base model validation:
  - src/pylibrelinkup/models/base.py (link): Added preprocess_data model validator to ConfigBaseModel that converts None → [] for list-type fields
- Model migration:
  - src/pylibrelinkup/models/login.py (link): Migrated 17 model classes to inherit from ConfigBaseModel, removed redundant field validator
- Test coverage:
  - tests/data/login_response_null_emailday.json (link): Added test fixture with emailDay: null
  - tests/test_client_authentication.py (link): Added test case test_authenticate_handles_null_emailday to verify the fix
