### PR TITLE
Fix/handle redirect in api calls

### DIFF
--- a/src/pylibrelinkup/exceptions.py
+++ b/src/pylibrelinkup/exceptions.py
@@ -14,8 +14,10 @@ class AuthenticationError(PyLibreLinkUpError):
 
 
 class RedirectError(PyLibreLinkUpError):
-    """Raised when a redirect is encountered during authentication. This is a signal to retry the request with the new region.
-    The new region is stored in the `region` attribute of the exception, which is an APIUrl enum value.
+    """Raised when the API indicates the request must be retried against a different regional host.
+
+    Can occur on the login request or on any subsequent API call. The new region is stored in the
+    `region` attribute of the exception, which is an APIUrl enum value.
     """
 
     def __init__(self, region: APIUrl):

--- a/src/pylibrelinkup/models/connection.py
+++ b/src/pylibrelinkup/models/connection.py
@@ -12,7 +12,8 @@ from .hardware import ActiveSensor, PatientDevice, Sensor
 
 __all__ = ["GraphResponse", "LogbookResponse"]
 
-from ..exceptions import PatientNotFoundError
+from ..api_url import APIUrl
+from ..exceptions import PatientNotFoundError, RedirectError
 
 
 class Connection(ConfigBaseModel):
@@ -82,6 +83,8 @@ class APIResponse(ConfigBaseModel):
                         "status": 4
                     }:  # 4 is the status code for "couldNotLoadPatient"
                         raise PatientNotFoundError()
+                    case {"data": {"redirect": True, "region": str(region)}}:
+                        raise RedirectError(APIUrl.from_string(region.upper()))
             # No match, raise the original exception
             raise
 

--- a/src/pylibrelinkup/models/connection.py
+++ b/src/pylibrelinkup/models/connection.py
@@ -69,22 +69,23 @@ class APIResponse(ConfigBaseModel):
     def validate_api_response(
         cls, data: Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        # Redirect payloads fail model validation, but that's coincidental — check
+        # explicitly so the behaviour doesn't silently break if the model changes.
+        if isinstance(data, dict):
+            match data:
+                case {"data": {"redirect": True, "region": str(region)}}:
+                    raise RedirectError(APIUrl.from_string(region))
         try:
             return handler(data)
         except ValidationError:
             # TODO: Add logging
-            # TODO: Extend this to handle other exceptions e.g. redirections, terms of use, etc.
-            # if the data is a dictionary, and it should contain an "error" and "status" key
-            # match against the status to determine what exception to raise
-            # if there's no match, raise the original exception
+            # TODO: Extend this to handle other exceptions e.g. terms of use, etc.
             if isinstance(data, dict):
                 match data:
                     case {
                         "status": 4
                     }:  # 4 is the status code for "couldNotLoadPatient"
                         raise PatientNotFoundError()
-                    case {"data": {"redirect": True, "region": str(region)}}:
-                        raise RedirectError(APIUrl.from_string(region.upper()))
             # No match, raise the original exception
             raise
 

--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -50,8 +50,15 @@ class PyLibreLinkUp:
     password: str
     token: str | None
     account_id_hash: str | None
+    timeout: float | tuple[float, float] | None
 
-    def __init__(self, email: str, password: str, api_url: APIUrl = APIUrl.US) -> None:
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        api_url: APIUrl = APIUrl.US,
+        timeout: float | tuple[float, float] | None = (10, 30),
+    ) -> None:
         """
         Constructor for the PyLibreLinkUp class.
 
@@ -61,6 +68,10 @@ class PyLibreLinkUp:
         :type password: str
         :param api_url: The regional API URL to use. Defaults to US.
         :type api_url: APIUrl
+        :param timeout: Request timeout in seconds. A float applies to both connect and
+            read; a ``(connect, read)`` tuple sets them independently. Pass ``None`` to
+            disable timeout. Defaults to ``(10, 30)``.
+        :type timeout: float | tuple[float, float] | None
         :return: None
         """
         self.login_args: LoginArgs = LoginArgs(email=email, password=password)
@@ -69,6 +80,7 @@ class PyLibreLinkUp:
         self.token = None
         self.account_id_hash = None
         self.api_url: str = api_url.value
+        self.timeout = timeout
 
     def _call_api(self, url: str) -> dict:
         """Calls the LibreLinkUp API and returns the response
@@ -76,7 +88,7 @@ class PyLibreLinkUp:
         :type url: str
         :rtype: object
         """
-        r = requests.get(url=url, headers=self._get_headers())
+        r = requests.get(url=url, headers=self._get_headers(), timeout=self.timeout)
         try:
             r.raise_for_status()
         except HTTPError as e:
@@ -136,6 +148,7 @@ class PyLibreLinkUp:
             url=f"{self.api_url}/llu/auth/login",
             headers=self._get_headers(),
             json=self.login_args.model_dump(),
+            timeout=self.timeout,
         )
         r.raise_for_status()
         data = r.json()

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -5,7 +5,7 @@ import responses
 from pydantic import ValidationError
 from requests import HTTPError
 
-from pylibrelinkup import APIUrl, LLUAPIRateLimitError
+from pylibrelinkup import APIUrl, LLUAPIRateLimitError, PyLibreLinkUp
 from pylibrelinkup.exceptions import RedirectError
 from tests.conftest import pylibrelinkup_client
 
@@ -133,3 +133,29 @@ def test_non_redirect_malformed_response_still_raises_validation_error(
 
     with pytest.raises(ValidationError):
         pylibrelinkup_client.client.latest(patient_identifier=patient_id)
+
+
+def test_call_api_passes_default_timeout(mocker):
+    """_call_api must forward the default (10, 30) timeout to requests.get."""
+    mock_get = mocker.patch("pylibrelinkup.pylibrelinkup.requests.get")
+    mock_response = mock_get.return_value
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {}
+
+    client = PyLibreLinkUp(email="x@example.com", password="secret")
+    client._call_api("https://example.com/test")
+
+    assert mock_get.call_args.kwargs["timeout"] == (10, 30)
+
+
+def test_call_api_passes_custom_timeout(mocker):
+    """_call_api must forward a caller-supplied timeout tuple to requests.get."""
+    mock_get = mocker.patch("pylibrelinkup.pylibrelinkup.requests.get")
+    mock_response = mock_get.return_value
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {}
+
+    client = PyLibreLinkUp(email="x@example.com", password="secret", timeout=(5, 60))
+    client._call_api("https://example.com/test")
+
+    assert mock_get.call_args.kwargs["timeout"] == (5, 60)

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -2,9 +2,10 @@ from uuid import UUID
 
 import pytest
 import responses
+from pydantic import ValidationError
 from requests import HTTPError
 
-from pylibrelinkup import LLUAPIRateLimitError
+from pylibrelinkup import APIUrl, LLUAPIRateLimitError
 from pylibrelinkup.exceptions import RedirectError
 from tests.conftest import pylibrelinkup_client
 
@@ -84,21 +85,51 @@ def test_call_api_successful_response(mocked_responses, pylibrelinkup_client):
     assert result == expected_data
 
 
+@pytest.mark.parametrize(
+    "endpoint, method_name",
+    [
+        ("graph", "latest"),
+        ("graph", "graph"),
+        ("logbook", "logbook"),
+    ],
+)
 def test_redirect_response_raises_redirect_error(
-    mocked_responses, pylibrelinkup_client
+    mocked_responses, pylibrelinkup_client, endpoint, method_name
 ):
-    """Test that redirect responses from API endpoints raise RedirectError."""
+    """Test that redirect responses from API endpoints raise RedirectError carrying the new region."""
     patient_id = UUID("12345678-1234-5678-1234-567812345678")
-    redirect_data = {"status": 0, "data": {"redirect": True, "region": "us"}}
+    redirect_data = {"status": 0, "data": {"redirect": True, "region": "eu"}}
 
     mocked_responses.add(
         responses.GET,
-        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/{endpoint}",
         json=redirect_data,
         status=200,
     )
 
     pylibrelinkup_client.client.token = "not_a_token"
 
-    with pytest.raises(RedirectError):
+    with pytest.raises(RedirectError) as exc_info:
+        getattr(pylibrelinkup_client.client, method_name)(patient_identifier=patient_id)
+
+    assert exc_info.value.region is APIUrl.EU
+
+
+def test_non_redirect_malformed_response_still_raises_validation_error(
+    mocked_responses, pylibrelinkup_client
+):
+    """Payloads without a redirect flag should fall through to the normal validation path."""
+    patient_id = UUID("12345678-1234-5678-1234-567812345678")
+    malformed_data = {"status": 0, "data": {"redirect": False}}
+
+    mocked_responses.add(
+        responses.GET,
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
+        json=malformed_data,
+        status=200,
+    )
+
+    pylibrelinkup_client.client.token = "not_a_token"
+
+    with pytest.raises(ValidationError):
         pylibrelinkup_client.client.latest(patient_identifier=patient_id)

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -1,8 +1,11 @@
+from uuid import UUID
+
 import pytest
 import responses
 from requests import HTTPError
 
 from pylibrelinkup import LLUAPIRateLimitError
+from pylibrelinkup.exceptions import RedirectError
 from tests.conftest import pylibrelinkup_client
 
 
@@ -79,3 +82,23 @@ def test_call_api_successful_response(mocked_responses, pylibrelinkup_client):
     result = pylibrelinkup_client.client._call_api(url)
 
     assert result == expected_data
+
+
+def test_redirect_response_raises_redirect_error(
+    mocked_responses, pylibrelinkup_client
+):
+    """Test that redirect responses from API endpoints raise RedirectError."""
+    patient_id = UUID("12345678-1234-5678-1234-567812345678")
+    redirect_data = {"status": 0, "data": {"redirect": True, "region": "us"}}
+
+    mocked_responses.add(
+        responses.GET,
+        f"{pylibrelinkup_client.api_url.value}/llu/connections/{patient_id}/graph",
+        json=redirect_data,
+        status=200,
+    )
+
+    pylibrelinkup_client.client.token = "not_a_token"
+
+    with pytest.raises(RedirectError):
+        pylibrelinkup_client.client.latest(patient_identifier=patient_id)

--- a/tests/test_client_authentication.py
+++ b/tests/test_client_authentication.py
@@ -180,3 +180,23 @@ def test_authenticate_handles_null_emailday(
 
     # Verify authentication succeeded
     assert pylibrelinkup_client.client.token == "parp"
+
+
+def test_authenticate_passes_timeout(mocker):
+    """authenticate must forward self.timeout to requests.post."""
+    import json
+    from pathlib import Path
+
+    login_data = json.loads(
+        (Path(__file__).parent / "data" / "login_response.json").read_text()
+    )
+
+    mock_post = mocker.patch("pylibrelinkup.pylibrelinkup.requests.post")
+    mock_response = mock_post.return_value
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = login_data
+
+    client = PyLibreLinkUp(email="x@example.com", password="secret", timeout=(3, 15))
+    client.authenticate()
+
+    assert mock_post.call_args.kwargs["timeout"] == client.timeout


### PR DESCRIPTION
The LLU API can return redirection responses to non-login requests, so the `_call_api` method should handle these in the same way that the login request does, by  raising a `RedirectError` that the calling code can deal with.

The better longer term solution is probably to provide the ability for any such requests to be retried with the region specified in the api response, but that can come later and is tracked in #76 
