### PR TITLE
Allow user to set custom user-agent 

### DIFF
--- a/src/pylibrelinkup/pylibrelinkup.py
+++ b/src/pylibrelinkup/pylibrelinkup.py
@@ -51,7 +51,13 @@ class PyLibreLinkUp:
     token: str | None
     account_id_hash: str | None
 
-    def __init__(self, email: str, password: str, api_url: APIUrl = APIUrl.US) -> None:
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        api_url: APIUrl = APIUrl.US,
+        user_agent: str | None = None,
+    ) -> None:
         """
         Constructor for the PyLibreLinkUp class.
 
@@ -61,6 +67,8 @@ class PyLibreLinkUp:
         :type password: str
         :param api_url: The regional API URL to use. Defaults to US.
         :type api_url: APIUrl
+        :param user_agent: Optional User-Agent header override.
+        :type user_agent: str | None
         :return: None
         """
         self.login_args: LoginArgs = LoginArgs(email=email, password=password)
@@ -69,6 +77,9 @@ class PyLibreLinkUp:
         self.token = None
         self.account_id_hash = None
         self.api_url: str = api_url.value
+        if user_agent and "\x00" in user_agent:
+            raise ValueError("user_agent must not contain null bytes")
+        self.user_agent: str | None = user_agent
 
     def _call_api(self, url: str) -> dict:
         """Calls the LibreLinkUp API and returns the response
@@ -115,6 +126,8 @@ class PyLibreLinkUp:
             headers.update({"authorization": "Bearer " + self.token})
         if self.account_id_hash:
             headers.update({"account-id": self.account_id_hash})
+        if self.user_agent:
+            headers.update({"User-Agent": self.user_agent})
         return headers
 
     def _get_logbook_json(self, patient_id: UUID) -> dict:

--- a/tests/test_client_user_agent.py
+++ b/tests/test_client_user_agent.py
@@ -1,0 +1,76 @@
+import pytest
+import responses
+
+from pylibrelinkup import APIUrl, PyLibreLinkUp
+from tests.conftest import pylibrelinkup_client
+
+
+def test_default_user_agent_is_none():
+    client = PyLibreLinkUp(email="test@example.com", password="password")
+    assert client.user_agent is None
+
+
+def test_user_agent_set_via_constructor():
+    ua = "Mozilla/5.0 (custom)"
+    client = PyLibreLinkUp(email="test@example.com", password="password", user_agent=ua)
+    assert client.user_agent == ua
+
+
+def test_user_agent_set_directly():
+    client = PyLibreLinkUp(email="test@example.com", password="password")
+    client.user_agent = "MyApp/1.0"
+    assert client.user_agent == "MyApp/1.0"
+
+
+def test_headers_contain_no_user_agent_by_default():
+    client = PyLibreLinkUp(email="test@example.com", password="password")
+    headers = client._get_headers()
+    assert "User-Agent" not in headers
+
+
+def test_headers_contain_user_agent_when_set():
+    ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+    client = PyLibreLinkUp(email="test@example.com", password="password", user_agent=ua)
+    headers = client._get_headers()
+    assert headers["User-Agent"] == ua
+
+
+def test_headers_contain_user_agent_when_set_directly():
+    client = PyLibreLinkUp(email="test@example.com", password="password")
+    client.user_agent = "MyCustomAgent/2.0"
+    headers = client._get_headers()
+    assert headers["User-Agent"] == "MyCustomAgent/2.0"
+
+
+def test_user_agent_sent_in_api_call(mocked_responses, pylibrelinkup_client):
+    """User-Agent header override is forwarded in actual HTTP requests."""
+    ua = "Mozilla/5.0 (test)"
+    pylibrelinkup_client.client.user_agent = ua
+    pylibrelinkup_client.client.token = "test_token"
+
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    mocked_responses.add(responses.GET, url, json={"status": 0}, status=200)
+
+    pylibrelinkup_client.client._call_api(url)
+
+    assert len(mocked_responses.calls) == 1
+    assert mocked_responses.calls[0].request.headers["User-Agent"] == ua
+
+
+def test_user_agent_not_in_headers_when_none(mocked_responses, pylibrelinkup_client):
+    """No User-Agent override means the key is absent from the sent headers."""
+    pylibrelinkup_client.client.token = "test_token"
+
+    url = f"{pylibrelinkup_client.api_url}/test/endpoint"
+    mocked_responses.add(responses.GET, url, json={"status": 0}, status=200)
+
+    pylibrelinkup_client.client._call_api(url)
+
+    assert "User-Agent" not in pylibrelinkup_client.client._get_headers()
+
+
+def test_null_byte_in_user_agent_raises():
+    with pytest.raises(ValueError, match="null bytes"):
+        PyLibreLinkUp(
+            email="test@example.com", password="password", user_agent="bad\x00value"
+        )


### PR DESCRIPTION
Introduce an optional `user_agent` param in the `PyLibreLinkUp` constructor, and set in `_get_headers` to ensure that it is included in all requests if set.